### PR TITLE
Make deployment more flexible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,15 @@
 FROM nginx:mainline-alpine
 
-ENV HTPASSWD='yleisviesti:$apr1$sM6OuSuR$aQ3xduEKmpDBmFx.QqrR1/'
+RUN apk add --no-cache python py-pip
 
-RUN apk add --no-cache python
-ADD https://bootstrap.pypa.io/get-pip.py get-pip.py
-
-RUN python get-pip.py
 RUN pip install tornado
 
+COPY run_yleisviesti.sh run_yleisviesti.sh
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY . /yleisviestipalvelu
 
-ADD run_yleisviesti.sh run_yleisviesti.sh
 RUN chmod +x run_yleisviesti.sh
 
-COPY nginx.conf /etc/nginx/nginx.conf
-
 EXPOSE 80
+
 CMD ["./run_yleisviesti.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+
+## yleisviestipalvelu
+
+### prerequisites
+
+You must have an APR1 formatted password hash, which can be created with openssl(1):
+
+    $ openssl passwd -apr1
+
+### usage
+
+Following assumes that you have build the Docker image and it is called `yleisviesti`.
+
+After building the image, you can run it with:
+
+    $ docker run -d -e PORT=8900 -e HTPASSWD='user:$apr1$salt$hash' -p 8080:80 yleisviesti
+
+When running the service in Swarm use a compose file such as:
+
+    version: '3.3'
+
+    services:
+      yleisviesti:
+        image: yleisviesti
+        ports:
+        - "8080:80"
+        environment:
+        - "PORT=8900"
+        - "HTPASSWD=user:$apr1$salt$hash"
+        volumes:
+        - /local/path:/yleisviestipalvelu/messages
+        deploy:
+          replicas: 1

--- a/handlers/index.py
+++ b/handlers/index.py
@@ -1,19 +1,20 @@
-import tornado.web
 import json
 import shutil
 import time
-import settings
 
+from tornado import web
 from tornado.options import options
 
-class ViewJson(tornado.web.RequestHandler):
+
+class ViewJson(web.RequestHandler):
     def get(self):
         with open(options.filename) as data_file:
             data = json.load(data_file)
 
         self.write(json.dumps(data, indent=4, ensure_ascii=False))
 
-class ViewEdit(tornado.web.RequestHandler):
+
+class ViewEdit(web.RequestHandler):
     def get(self):
         with open(options.filename) as data_file:
             data = json.load(data_file)
@@ -24,13 +25,15 @@ class ViewEdit(tornado.web.RequestHandler):
             json=json.dumps(data)
         )
 
-class CopyJson(tornado.web.RequestHandler):
+
+class CopyJson(web.RequestHandler):
     def post(self):
         # retrieve the message as json
         data = json.loads(self.request.body.decode('utf-8'))
 
         # first copy the file to archive
-        shutil.copy2(options.filename, options.filepath + 'yleisviesti_' + time.strftime("%d%m%Y_%H%M%S") + '.json')
+        shutil.copy2(options.filename, options.filepath + 'yleisviesti_' +
+                     time.strftime("%d%m%Y_%H%M%S") + '.json')
 
         # open existing file and overwrite it with new json
         with open(options.filename, 'w') as outfile:

--- a/main.py
+++ b/main.py
@@ -1,16 +1,14 @@
-import os
-import tornado.httpserver
-import tornado.ioloop
-import tornado.web
-import tornado.autoreload
-import settings
-
-from tornado.options import define, options
-from tornado.web import url
+from os.path import dirname, join
 
 import handlers.index
+import settings  # pylint: disable=unused-import
 
-class Application(tornado.web.Application):
+from tornado import autoreload, httpserver, ioloop, web
+from tornado.options import options
+from tornado.web import url
+
+
+class Application(web.Application):
     def __init__(self):
         routes = [
             url(r"/", handlers.index.ViewJson, name='index'),
@@ -18,22 +16,24 @@ class Application(tornado.web.Application):
             url(r"/copyJson", handlers.index.CopyJson, name='kopioi')
         ]
 
-        settings = dict(
-            template_path=os.path.join(os.path.dirname(__file__), "templates"),
-            static_path=os.path.join(os.path.dirname(__file__), "static")
+        config = dict(
+            template_path=join(dirname(__file__), "templates"),
+            static_path=join(dirname(__file__), "static")
         )
 
-        tornado.web.Application.__init__(self, routes, **settings)
+        web.Application.__init__(self, routes, **config)
+
 
 def main():
-    tornado.options.parse_command_line()
-    http_server = tornado.httpserver.HTTPServer(Application())
+    options.parse_command_line()
+    http_server = httpserver.HTTPServer(Application())
     http_server.listen(options.port)
 
     print "Listening on port: " + str(options.port)
-    tornado.autoreload.start()
+    autoreload.start()
 
-    tornado.ioloop.IOLoop.instance().start()
+    ioloop.IOLoop.instance().start()
+
 
 if __name__ == "__main__":
     main()

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,81 +1,70 @@
 daemon off;
-
-user  nginx;
-worker_processes  1;
-
-error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
-
+user   nginx;
+pid    /var/run/nginx.pid;
 
 events {
-    worker_connections  1024;
+    worker_connections 1024;
 }
 
-
 http {
-    include       /etc/nginx/mime.types;
-    default_type  application/octet-stream;
+    include      /etc/nginx/mime.types;
+    default_type application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log /var/log/nginx/access.log main;
+    error_log  /var/log/nginx/error.log  warn;
 
-    sendfile        on;
-    #tcp_nopush     on;
-
-    keepalive_timeout  65;
-
-    gzip  on;
+    gzip              on;
+    sendfile          on;
+    keepalive_timeout 65;
+    port_in_redirect  off;
 
     server {
-	    listen       80;
-	    server_name  _;
-	    access_log   off;
-	    root         /yleisviestipalvelu/messages;
-
+        server_name _;
+        listen      80;
+        root        /yleisviestipalvelu/messages;
+        index       yleisviesti.json;
+        autoindex   on;
 
         location / {
-             if ($request_method = 'OPTIONS') {
-		        add_header 'Access-Control-Allow-Origin' '*';
-		        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-		        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-		        add_header 'Access-Control-Max-Age' 1728000;
-		        add_header 'Content-Type' 'text/plain; charset=utf-8';
-		        add_header 'Content-Length' 0;
-		        return 204;
-		     }
-		     if ($request_method = 'POST') {
-		        add_header 'Access-Control-Allow-Origin' '*';
-		        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-		        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-		        add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-		     }
-		     if ($request_method = 'GET') {
-		        add_header 'Access-Control-Allow-Origin' '*';
-		        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-		        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-		        add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-		     }
-    		index yleisviesti.json;
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain; charset=utf-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+            if ($request_method = 'POST') {
+                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+                add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+            }
+            if ($request_method = 'GET') {
+                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+                add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+            }
+
+            expires   1m;
             try_files $uri $uri/ /index.html;
-            autoindex on;
-            expires 1m;
         }
 
-
-		location /ui/ {
-			auth_basic              "Rajoitettu";
-     		auth_basic_user_file    /etc/nginx/auth.htpasswd;
-            proxy_pass_header Server;
-            proxy_set_header Host $http_host;
-            proxy_redirect off;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Scheme $scheme;		
-		    proxy_pass       http://localhost:8900/;
-		}
-
-	  }
-
+        location /ui/ {
+            auth_basic           "Rajoitettu";
+            auth_basic_user_file /etc/nginx/auth.htpasswd;
+            proxy_redirect       off;
+            proxy_pass_header    Server;
+            proxy_set_header     Host $http_host;
+            proxy_set_header     X-Scheme $scheme;
+            proxy_set_header     X-Real-IP $remote_addr;
+            proxy_pass           http://localhost:8900/;
+        }
+    }
 }

--- a/run_yleisviesti.sh
+++ b/run_yleisviesti.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
+
+set -e
+
 cd yleisviestipalvelu
 mkdir -p messages/archive
-echo "{\"staticMessages\": []}" > messages/yleisviesti.json
-python main.py --port=8900 --filename=messages/yleisviesti.json --filepath=messages/archive & > /dev/null
 
-echo ${HTPASSWD} > /etc/nginx/auth.htpasswd
+echo "${HTPASSWD}" > /etc/nginx/auth.htpasswd
+echo '{"staticMessages": []}' > messages/yleisviesti.json
 
-nginx
+python main.py --port=${PORT} --filename=messages/yleisviesti.json --filepath=messages/archive &
+
+/usr/sbin/nginx

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,6 @@
-from tornado.options import define, options
+from tornado.options import define
 
 define("port", default=8900, help="run on the given port", type=int)
-define("filename", default="yleisviesti-latest.json", help="the served file", type=str)
 define("filepath", default="archive/", help="path for backup files", type=str)
+define("filename", default="yleisviesti-latest.json", help="the served file",
+       type=str)

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,8 @@
+from os import getenv
 from tornado.options import define
 
-define("port", default=8900, help="run on the given port", type=int)
-define("filepath", default="archive/", help="path for backup files", type=str)
+define("port", default=getenv('PORT', 8900), help="run on the given port",
+       type=int)
 define("filename", default="yleisviesti-latest.json", help="the served file",
        type=str)
+define("filepath", default="archive/", help="path for backup files", type=str)


### PR DESCRIPTION
This PR is mostly motivated by making Docker Swarm deployment easier, and should not introduce changes to actual service logic.

More relevant changes:

* Drop basic auth hash from Dockerfile, so that the password can be changed without rebuilding
* Allow the backend port to be controlled via environment variable
* Enabled nginx logging

Changes which tagged along:

* Add readme
* Improve code style as suggested by pylint and pep8
* Switch to Alpine packaged pip to make build quicker